### PR TITLE
Use systemd to manage service startup when available

### DIFF
--- a/slapd-cli
+++ b/slapd-cli
@@ -227,6 +227,17 @@ else
 	message "info" "[INFO] Using built-in configuration - this may cause some problems"
 fi
 
+# Use systemd to manage the service if it's present
+_use_systemctl=0
+if [ $PPID -ne 1 -a -z "$SYSTEMCTL_SKIP_REDIRECT" ] && \
+    [ -d /run/systemd/system ] && \
+    [ -z "$INVOCATION_ID" ]  ;
+
+then
+	SYSTEMD_SERVICE_NAME=slapd
+	_use_systemctl=1
+fi
+
 #====================================================================
 # Initiate 'su' command
 #====================================================================
@@ -370,7 +381,11 @@ start_slapd() {
 	if [ -n "$1" ]; then
 		$SLAPD_BIN -h "$SLAPD_SERVICES" $SLAPD_PARAMS -d $1
 	else
-		$SLAPD_BIN -h "$SLAPD_SERVICES" $SLAPD_PARAMS
+		if [ $_use_systemctl -eq 1 ] ; then
+			systemctl start "$SYSTEMD_SERVICE_NAME"
+		else
+			$SLAPD_BIN -h "$SLAPD_SERVICES" $SLAPD_PARAMS
+		fi
 		sleep 1
 
 		# Presence of PID file
@@ -447,24 +462,29 @@ stop_slapd() {
 		message "info" "[INFO] Can't read PID file, to stop OpenLDAP try: $0 forcestop"
 		return 1
 	else
-		PID=`cat $SLAPD_PID_FILE`
-		kill -INT $PID
+		if [ $_use_systemctl -eq 1 ] ; then
+			systemctl stop "$SYSTEMD_SERVICE_NAME"
+			message "info" "[OK] OpenLDAP stopped"
+		else
+			PID=`cat $SLAPD_PID_FILE`
+			kill -INT $PID
+			# Waiting loop
+			i=0
+			while [ -e /proc/$PID ]
+			do
+				if [ $i -eq $TIMEOUT ]
+				then
+					# Timeout
+					message "alert" "[ALERT] OpenLDAP still running (PID $PID), try: $0 forcestop"
+					exit 1
+				fi
+				i=`expr $i + 1`
+				sleep 1
+			done
 
-		# Waiting loop
-		i=0
-		while [ -e /proc/$PID ]
-		do
-			if [ $i -eq $TIMEOUT ]
-			then
-				# Timeout
-				message "alert" "[ALERT] OpenLDAP still running (PID $PID), try: $0 forcestop"
-				exit 1
-			fi
-			i=`expr $i + 1`
-			sleep 1
-		done
+			message "info" "[OK] OpenLDAP stopped after $i seconds"
+		fi
 
-		message "info" "[OK] OpenLDAP stopped after $i seconds"
 	fi
 
 	# Backup if necessary
@@ -588,6 +608,16 @@ forcestop() {
 }
 
 slapd_status() {
+	if [ $_use_systemctl -eq 1 ]
+	then
+		if systemctl --quiet is-active "$SYSTEMD_SERVICE_NAME"
+		then
+			return 0
+		else
+			return 1
+		fi
+	fi
+
 	# Return 0 if slapd is running, 1 if slapd is stopped, 2 if we can't say
 	if [ ! -r $SLAPD_PID_FILE ]
 	then

--- a/slapd-cli
+++ b/slapd-cli
@@ -229,10 +229,17 @@ fi
 
 # Use systemd to manage the service if it's present
 _use_systemctl=0
-if [ $PPID -ne 1 -a -z "$SYSTEMCTL_SKIP_REDIRECT" ] && \
-    [ -d /run/systemd/system ] && \
-    [ -z "$INVOCATION_ID" ]  ;
 
+# When systemd runs a shell script, bash sets PPID to 1 (init)
+if [ $PPID -ne 1 ] && \
+    # This variable lets the user disable systemd redirection
+    [ -z "$SYSTEMCTL_SKIP_REDIRECT" ] && \
+    # This tests whether systemd is currently managing the systemd
+    [ -d /run/systemd/system ] && \
+    # This variable is set when systemd >=232 runs a service
+    # We need this test in case systemd does not run the slapd-cli script
+    # directly (PPID>1) but runs it through /etc/init.d/slapd
+    [ -z "$INVOCATION_ID" ]  ;
 then
 	SYSTEMD_SERVICE_NAME=slapd
 	_use_systemctl=1


### PR DESCRIPTION
When launching slapd through "slapd-cli start", on a systemd install, the process will not be seen as active by systemd (systemctl status slapd). In order to be correctly supervised, the slapd process must be started by systemd even when `slapd-cli start` is run.

This commit makes slapd startup/shutdown go through systemd, when
available (/run/systemd/system exists). 

Since systemd calls slapd-cli to start open ldap too, to avoid infinite
recursion, we need if slapd-cli is being run by a user or by systemd
itself (PPID=1)

Finally, SYSTEMCTL_SKIP_REDIRECT allows the behavior to be bypassed

Heavily inspired by legacy initscript behavior on RHEL7
(/etc/init.d/functions)

Tested on Debian 9 and Centos 7 so far